### PR TITLE
Adding CondensedHomotopySolver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(continuation_sources
   problems/NLMCProblems.cpp
   problems/OptProblems.cpp
   solvers/HomotopySolver.cpp
+  solvers/CondensedHomotopySolver.cpp
   solvers/IPSolver.cpp
   utilities.cpp)
 
@@ -51,6 +52,7 @@ set(continuation_headers
   problems/Problems.hpp
   solvers/Solvers.hpp
   solvers/HomotopySolver.hpp
+  solvers/CondensedHomotopySolver.hpp
   solvers/IPSolver.hpp
   utilities.hpp)
 

--- a/TestProblems/TestProblem1a.cpp
+++ b/TestProblems/TestProblem1a.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include "../problems/Problems.hpp"
 #include "../solvers/HomotopySolver.hpp"
+#include "../solvers/CondensedHomotopySolver.hpp"
 #include "../utilities.hpp"
 
 using namespace std;
@@ -73,12 +74,16 @@ int main(int argc, char *argv[])
    
    real_t nmcpSolverTol = 1.e-8;
    int nmcpSolverMaxIter = 30;
+   bool condensed_solve = false;
    args.AddOption(&n, "-n", "--n", 
 		   "Size of optimization variable.");
    args.AddOption(&nmcpSolverTol, "-nmcptol", "--nmcp-tol", 
 		   "Tolerance for NMCP solver.");
    args.AddOption(&nmcpSolverMaxIter, "-nmcpmaxiter", "--nmcp-maxiter",
                   "Maximum number of iterations for the NMCP solver.");
+   args.AddOption(&condensed_solve, "-condensed-solve", "--condensed-solve", "-monolithic-solve",
+                  "--monolithic-solve",
+                  "Whether or not to use the CondensedHomotopySolver.");
    args.Parse();
    if (!args.Good())
    {
@@ -107,6 +112,11 @@ int main(int argc, char *argv[])
    HomotopySolver solver(&problem);
    solver.SetTol(nmcpSolverTol);
    solver.SetMaxIter(nmcpSolverMaxIter);
+   CondensedHomotopySolver condensed_solver;
+   if (condensed_solve)
+   {
+      solver.SetLinearSolver(condensed_solver);
+   }
    solver.Mult(x0, y0, xf, yf);
    bool converged = solver.GetConverged();
    MFEM_VERIFY(converged, "solver did not converge\n");

--- a/solvers/CondensedHomotopySolver.cpp
+++ b/solvers/CondensedHomotopySolver.cpp
@@ -1,0 +1,144 @@
+
+#include "CondensedHomotopySolver.hpp"
+
+
+void CondensedHomotopySolver::SetOperator(const mfem::Operator& op)
+{
+   auto blkOp = dynamic_cast<const mfem::BlockOperator *>(&op);
+   MFEM_VERIFY(blkOp, "op must be a mfem::BlockOperator!");
+   blkOp->RowOffsets().Copy(blockOffsets);
+
+   // Extract blocks
+   auto A00 = dynamic_cast<const mfem::HypreParMatrix *>(&blkOp->GetBlock(0, 0));
+   auto A01 = dynamic_cast<const mfem::HypreParMatrix *>(&blkOp->GetBlock(0, 1));
+   auto A10 = dynamic_cast<const mfem::HypreParMatrix *>(&blkOp->GetBlock(1, 0));
+   auto A11 = dynamic_cast<const mfem::HypreParMatrix *>(&blkOp->GetBlock(1, 1));
+   A12 = dynamic_cast<const mfem::HypreParMatrix *>(&blkOp->GetBlock(1, 2));
+   A20 = dynamic_cast<const mfem::HypreParMatrix *>(&blkOp->GetBlock(2, 0));
+   auto A22 = dynamic_cast<const mfem::HypreParMatrix *>(&blkOp->GetBlock(2, 2));
+
+   // A00, A01, A10, A11 are diagonal matrices
+   // TODO: add a check?
+   mfem::Vector A00_d, A01_d, A10_d, A11_d;
+   A00->GetDiag(A00_d);
+   A01->GetDiag(A01_d);
+   A10->GetDiag(A10_d);
+   A11->GetDiag(A11_d);
+
+   // scaleij is the diagonal of the (i,j) block of 
+   //                [A00 A01]^-1
+   //                [A10 A11]
+   // scale11 = (A11 - A10 * A00^{-1} * A01)^{-1}
+   scale11 = A10_d;
+   scale11 /= A00_d;
+   scale11 *= A01_d;
+   scale11.Neg();
+   scale11 += A11_d;
+   scale11.Reciprocal();
+
+   // scale01 = -A00^{-1} * A01 * scale11
+   // scale10 = -scale11 * A10 * A00^{-1}
+   scale01 = scale11;
+   scale01 /= A00_d;
+   scale01.Neg();
+   scale10 = scale01;
+   scale01 *= A01_d;
+   scale10 *= A10_d;
+
+   // scale00 = A00^{-1} + A00^{-1} * A01 * scale11 * A10 * A00^{-1}
+   scale00 = scale01;
+   scale00.Neg();
+   scale00 *= A10_d;
+   scale00 += 1.0;
+   scale00 /= A00_d;
+
+   mfem::HypreParMatrix scaledA12(*A12);
+   scale01.Neg();
+   scaledA12.ScaleRows(scale01);
+   scale01.Neg();
+   mfem::HypreParMatrix * scaledProduct = mfem::ParMult(A20, &scaledA12);
+   // FIXME: this requires A22 and scaledProduct to have the same offd_colmap?
+   Areduced = ParAdd(A22, scaledProduct);
+   delete scaledProduct;
+
+   if (AreducedSolver)
+   {
+      AreducedSolver->SetOperator(*Areduced);
+   }
+}
+
+void CondensedHomotopySolver::Mult(const mfem::Vector &b, mfem::Vector &x) const
+{
+   mfem::BlockVector blk_x(x.GetData(), blockOffsets);
+   mfem::BlockVector blk_b(b.GetData(), blockOffsets);
+   Mult(blk_b, blk_x);
+}
+
+void CondensedHomotopySolver::Mult(const mfem::BlockVector& b, mfem::BlockVector& x) const
+{
+   mfem::Vector scaled_b0(b.GetBlock(0));
+   mfem::Vector scaled_b1(b.GetBlock(1));
+   mfem::Vector b_reduced(b.GetBlock(2));
+
+   // form RHS for reduced system
+   scaled_b0 *= scale00;
+   scaled_b1 *= scale01;
+   scaled_b0 += scaled_b1;
+   A20->Mult(-1.0, scaled_b0, 1.0, b_reduced);
+
+   if (AreducedSolver)
+   {
+      AreducedSolver->Mult(b_reduced, x.GetBlock(2));
+   }
+   else
+   {
+#ifdef MFEM_USE_STRUMPACK
+      auto defaultSolver = new mfem::STRUMPACKSolver(MPI_COMM_WORLD);
+      defaultSolver->SetKrylovSolver(strumpack::KrylovSolver::DIRECT);
+      defaultSolver->SetReorderingStrategy(strumpack::ReorderingStrategy::METIS);
+      auto Astrumpack = new mfem::STRUMPACKRowLocMatrix(*Areduced);
+      defaultSolver->SetOperator(*Astrumpack);
+#elif defined(MFEM_USE_MUMPS)
+      auto defaultSolver = new mfem::MUMPSSolver(MPI_COMM_WORLD);
+      defaultSolver->SetPrintLevel(0);
+      defaultSolver->SetMatrixSymType(mfem::MUMPSSolver::MatType::UNSYMMETRIC);
+      defaultSolver->SetOperator(*Areduced);
+#elif defined(MFEM_USE_MKL_CPARDISO)
+      auto defaultSolver = new mfem::CPardisoSolver(MPI_COMM_WORLD);
+      defaultSolver->SetOperator(*Areduced);
+#else
+      MFEM_ABORT("default (direct solver) will not work unless compiled mfem is with MUMPS, MKL_CPARDISO, or STRUMPACK");
+#endif
+      defaultSolver->Mult(b_reduced, x.GetBlock(2));
+
+      delete defaultSolver;
+#ifdef MFEM_USE_STRUMPACK
+      delete Astrumpack;
+#endif
+   }
+
+   // recover the solution to the original system
+   mfem::Vector helper0(b.GetBlock(0));
+   mfem::Vector helper1(b.GetBlock(1));
+   A12->Mult(-1.0, x.GetBlock(2), 1.0, helper1);
+
+   x.GetBlock(0) = helper0;
+   mfem::Vector scaledHelper1(helper1);
+   x.GetBlock(0) *= scale00;
+   scaledHelper1 *= scale01;
+   x.GetBlock(0) += scaledHelper1;
+
+   x.GetBlock(1) = helper0;
+   scaledHelper1 = helper1;
+   x.GetBlock(1) *= scale10;
+   scaledHelper1 *= scale11;
+   x.GetBlock(1) += scaledHelper1;
+}
+
+CondensedHomotopySolver::~CondensedHomotopySolver()
+{
+   if (Areduced)
+   {
+      delete Areduced;
+   }
+}

--- a/solvers/CondensedHomotopySolver.hpp
+++ b/solvers/CondensedHomotopySolver.hpp
@@ -1,0 +1,49 @@
+#include "mfem.hpp"
+#include "../problems/OptProblems.hpp"
+
+
+#ifndef CONDENSEDHOMOTOPYSOLVER 
+#define CONDENSEDHOMOTOPYSOLVER
+
+class CondensedHomotopySolver : public mfem::Solver
+{
+protected:
+	mfem::HypreParMatrix* Areduced;
+	mfem::Solver* AreducedSolver;
+	mfem::Array<int> blockOffsets;
+	mfem::Vector scale00;
+	mfem::Vector scale01;
+	mfem::Vector scale10;
+	mfem::Vector scale11;
+	const mfem::HypreParMatrix* A12;
+	const mfem::HypreParMatrix* A20;
+    
+public:
+	CondensedHomotopySolver() = default;
+
+	/// Set the solver for the reduced system.
+	void SetPreconditioner(mfem::Solver &solver) { AreducedSolver = &(solver); };
+
+	/**
+	 * @brief Sets the linear system to be solved.
+	 *
+	 * This builds a reduced system and the blocks needed to form the reduced RHS.
+	 * Also, it updates the solver for the reduced system.
+	 * The reduced system is:
+	 *     A22 + A20 * A00^{-1} * A01 * (A11 - A10 * A00^{-1} * A01)^{-1} * A12
+	 * 
+	 * @param op The operator is expected to be a BlockOperator of the form:
+	 *                            [A00 A01 0  ]
+	 *                            [A10 A11 A12]
+	 *                            [A20 0   A22]
+	 *           where A00, A01, A10, and A11 are diagonal matrices.
+	 */
+	void SetOperator(const mfem::Operator& op) override;
+
+	void Mult(const mfem::Vector&, mfem::Vector &) const override; 
+	void Mult(const mfem::BlockVector& , mfem::BlockVector&) const;
+
+	virtual ~CondensedHomotopySolver();
+};
+
+#endif // CONDENSEDHOMOTOPYSOLVER


### PR DESCRIPTION
This PR adds a condensed solver for solving the Jacobian system (3x3 block structure) in the Newton update. The solver condenses/reduces the 3x3 block system to a problem on one of the blocks only.

Right now, the solver for the reduced system is to be provided by the user (via `CondensedHomotopySolver::SetPreconditioner`). If no solver is provided, by default it will use some direct solver (depending on how mfem is built).